### PR TITLE
Add FIRST event code redirect

### DIFF
--- a/pages/events/first-code/[season]/[first_code].tsx
+++ b/pages/events/first-code/[season]/[first_code].tsx
@@ -1,0 +1,26 @@
+import TOAProvider from '@/providers/toa-provider';
+import { GetServerSideProps, NextPage } from 'next';
+
+const FirstCodePage: NextPage = () => {
+  return <></>;
+};
+
+export default FirstCodePage;
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  const events = await TOAProvider.getAPI().getEvents({ season_key: String(params?.season) });
+  const matchingEvents = events.filter(e => e.firstEventCode === String(params?.first_code));
+
+  if (matchingEvents.length !== 1) {
+    return {
+      notFound: true
+    };
+  }
+
+  return {
+    redirect: {
+      permanent: true,
+      destination: `/events/${matchingEvents[0].eventKey}`
+    }
+  };
+};


### PR DESCRIPTION
Adds a simple route which finds an event in the given season with a matching FIRST event code and redirects to the event page if found, otherwise returns the standard 404 page.

It's a bit unfortunate that the server has to pull in so much data, but I don't see any API parameters that would allow further filtering of the list.
